### PR TITLE
pass argument to load-rules function

### DIFF
--- a/iptable-tools.sh
+++ b/iptable-tools.sh
@@ -188,7 +188,7 @@ if [ -n "${DORESET}" ]; then
 fi
 if [ -n "${DOLOAD}" ]; then
   if [ -d "${RULESDIR}" ]; then
-    load-rules
+    load-rules "${RULESDIR}"
   else
     echo "Provided rules directory does not exist: ${RULESDIR}"
     exit 2


### PR DESCRIPTION
`load-rules` function won't work without passing argument